### PR TITLE
Adicionando calendário a tela de lembretes

### DIFF
--- a/lib/pages/reminderPage.dart
+++ b/lib/pages/reminderPage.dart
@@ -1,32 +1,58 @@
 import 'package:flutter/material.dart';
-import 'package:miocardio_paciente/functions/localization.dart' show Localization;
+import 'package:miocardio_paciente/functions/localization.dart'
+    show Localization;
+import 'package:table_calendar/table_calendar.dart';
 
 class ReminderPage extends StatefulWidget {
   ReminderPageState createState() => ReminderPageState();
 }
 
 class ReminderPageState extends State<ReminderPage> {
+  CalendarController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = CalendarController();
+  }
+
   @override
   Widget build(BuildContext context) {
     var localization = Localization.of(context);
     return Scaffold(
-      backgroundColor: Color.fromRGBO(253, 224, 224, 1),
-      body: ListView.builder(
-          itemCount: 1,
-          padding: EdgeInsets.all(5),
-          itemBuilder: (BuildContext context, int index) => Container(
-                padding: EdgeInsets.only(top: 30, bottom: 10),
-                child: Text(
-                  localization.trans('pagetitleReminder'),
-                  key: Key("pagetitleReminder"),
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    color: Colors.black,
-                    fontSize: 25,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              )),
-    );
+        backgroundColor: Color.fromRGBO(253, 224, 224, 1),
+        body: bodyData(localization));
   }
+
+  Widget bodyData(localization) => Scaffold(
+        backgroundColor: Color.fromRGBO(253, 224, 224, 1),
+        appBar: AppBar(
+          backgroundColor: Color.fromRGBO(253, 224, 224, 1),
+          title: title(localization),
+        ),
+        body: Container(
+          child: Column(
+            children: <Widget>[calendar()],
+          ),
+        ),
+      );
+
+  Widget title(localization) => Center(
+        child: Text(localization.trans('pagetitleReminder'),
+            key: Key("pagetitleReminder"),
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: Colors.black,
+              fontSize: 25,
+              fontWeight: FontWeight.bold,
+            )),
+      );
+
+ //Retorna o calendario da pagina
+  Widget calendar() => TableCalendar(
+        calendarStyle: CalendarStyle(
+          todayColor: Colors.purpleAccent,
+        ),
+        calendarController: _controller,
+      );
 }

--- a/lib/pages/reminderPage.dart
+++ b/lib/pages/reminderPage.dart
@@ -29,12 +29,12 @@ class ReminderPageState extends State<ReminderPage> {
         appBar: AppBar(
           backgroundColor: Color.fromRGBO(253, 224, 224, 1),
           title: title(localization),
+          elevation: 0.0,
         ),
-        body: Container(
-          child: Column(
-            children: <Widget>[calendar()],
-          ),
-        ),
+        body: ListView(
+          children: <Widget>[calendar(localization)],
+        )
+        
       );
 
   Widget title(localization) => Center(
@@ -48,11 +48,33 @@ class ReminderPageState extends State<ReminderPage> {
             )),
       );
 
- //Retorna o calendario da pagina
-  Widget calendar() => TableCalendar(
-        calendarStyle: CalendarStyle(
-          todayColor: Colors.purpleAccent,
+  //Retorna o calendario da pagina
+  Widget calendar(localization) => TableCalendar(
+        key: Key("calendarKey"),
+        locale: 'pt_BR',
+        headerStyle: HeaderStyle(
+          centerHeaderTitle: true,
+          formatButtonVisible: false,
         ),
+        calendarStyle: CalendarStyle(
+          todayColor: Color.fromRGBO(249, 124, 124, 0.6),
+        ),
+        onDaySelected: (date, events) {
+          print(date.toString());
+          print(localization.locale.toString());
+        },
+        builders: CalendarBuilders(
+            selectedDayBuilder: (context, date, events) => dayStyle(date, 1),
+            todayDayBuilder: (context, date, events) => dayStyle(date, 0.5)),
         calendarController: _controller,
+      );
+
+  //Estilo dos dias
+  Widget dayStyle(date, double transparency) => Container(
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+            color: Color.fromRGBO(249, 124, 124, transparency),
+            borderRadius: BorderRadius.circular(4.0)),
+        child: Text(date.day.toString(), style: TextStyle(color: Colors.white)),
       );
 }

--- a/lib/pages/reminderPage.dart
+++ b/lib/pages/reminderPage.dart
@@ -9,7 +9,10 @@ class ReminderPage extends StatefulWidget {
 
 class ReminderPageState extends State<ReminderPage> {
   CalendarController _controller;
+  Map<DateTime, List> _events;
 
+  bool isEmpty(String s) => s == null || s.isEmpty;
+  
   @override
   void initState() {
     super.initState();
@@ -49,24 +52,40 @@ class ReminderPageState extends State<ReminderPage> {
       );
 
   //Retorna o calendario da pagina
-  Widget calendar(localization) => TableCalendar(
+  Widget calendar(localization){
+    //captura a localização do dispositivo
+    bool isEmpty(String s) => s == null || s.isEmpty;
+    String locale = Localizations.localeOf(context).languageCode.toString();
+    locale += isEmpty(Localizations.localeOf(context).countryCode) ? "" : "_" + Localizations.localeOf(context).countryCode.toString().toUpperCase();
+    
+    //carregando eventos antes de criar o calendário
+    updateEvents();
+
+    return TableCalendar(
         key: Key("calendarKey"),
-        locale: 'pt_BR',
+        locale: locale,
         headerStyle: HeaderStyle(
           centerHeaderTitle: true,
           formatButtonVisible: false,
         ),
         calendarStyle: CalendarStyle(
           todayColor: Color.fromRGBO(249, 124, 124, 0.6),
+          markersColor: Color.fromRGBO(50, 50, 50, 0.5),
+          markersMaxAmount: 3,
         ),
         onDaySelected: (date, events) {
+          print(locale);
+          updateCards(date);
           setState(() {});
         },
         builders: CalendarBuilders(
             selectedDayBuilder: (context, date, events) => dayStyle(date, 1),
-            todayDayBuilder: (context, date, events) => dayStyle(date, 0.5)),
+            todayDayBuilder: (context, date, events) => dayStyle(date, 0.5)
+        ),
         calendarController: _controller,
+        events: _events,
       );
+  }
 
   //Estilo dos dias
   Widget dayStyle(date, double transparency) => Container(
@@ -76,4 +95,13 @@ class ReminderPageState extends State<ReminderPage> {
             borderRadius: BorderRadius.circular(4.0)),
         child: Text(date.day.toString(), style: TextStyle(color: Colors.white)),
       );
+
+  void updateCards(date){
+    //atualiza os lembretes
+  }
+
+  void updateEvents(){
+    _events = {};
+    //carrega a lista de eventos
+  }
 }

--- a/lib/pages/reminderPage.dart
+++ b/lib/pages/reminderPage.dart
@@ -4,7 +4,7 @@ import 'package:miocardio_paciente/functions/localization.dart'
 import 'package:table_calendar/table_calendar.dart';
 
 class ReminderPage extends StatefulWidget {
-  ReminderPageState createState() => ReminderPageState();
+  ReminderPageState createState() => new ReminderPageState();
 }
 
 class ReminderPageState extends State<ReminderPage> {
@@ -60,8 +60,7 @@ class ReminderPageState extends State<ReminderPage> {
           todayColor: Color.fromRGBO(249, 124, 124, 0.6),
         ),
         onDaySelected: (date, events) {
-          print(date.toString());
-          print(localization.locale.toString());
+          setState(() {});
         },
         builders: CalendarBuilders(
             selectedDayBuilder: (context, date, events) => dayStyle(date, 1),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -296,6 +296,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.3"
+  simple_gesture_detector:
+    dependency: transitive
+    description:
+      name: simple_gesture_detector
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -343,6 +350,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
+  table_calendar:
+    dependency: "direct main"
+    description:
+      name: table_calendar
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.1"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_cupertino_localizations: ^1.0.1
+  table_calendar: ^2.2.1
   cupertino_icons: ^0.1.2
 
 dev_dependencies:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -234,11 +234,14 @@ void main() {
       // Busca e verificando titulo
       Finder pageTitle = find.text('Lembretes');
       expect(pageTitle, findsOneWidget);
+      //Verifica a presenca do Calendario
+      Finder calendar = find.byKey(Key("calendarKey"));
+      expect(calendar, findsOneWidget);
       print("-------------------------------- APROVADO");
     });
   });
 
-  testWidgets('Testando reminder (portugues)', (WidgetTester tester) async {
+  testWidgets('Testando reminder (ingles)', (WidgetTester tester) async {
     await tester.runAsync(() async {
       Widget widget = MediaQuery(
                                   data: MediaQueryData(),
@@ -259,6 +262,10 @@ void main() {
       // Busca e verificando titulo
       Finder pageTitle = find.text('Reminder');
       expect(pageTitle, findsOneWidget);
+      
+      //Verifica a presenca do Calendario
+      Finder calendar = find.byKey(Key("calendarKey"));
+      expect(calendar, findsOneWidget);
       print("-------------------------------- APROVADO");
     });
   });


### PR DESCRIPTION
Fechando a issue #15, foi adicionado tanto o calendário à tela de lembretes como os métodos para agir ao clique de um dia e para construir a lista de eventos.
Falta integrar a criação dos cards (issue #37) e ao banco de dados (issue #18).